### PR TITLE
Bump avogadroapp (fix) and avogadrolibs (features)

### DIFF
--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -61,12 +61,12 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: efc404c5051cbd572878d0907297c0e4b2ee2920
+        commit: c7c578bec42ba348b08608e0fb151b12b1a721b6
         dest: avogadroapp
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: 389321120f8c6f83066f7a4d4e0496b474944b58
+        commit: ca9fa205fde785aed2282ae36acd7c83a7184f5c
         dest: avogadrolibs
       # avogadro-i18n
       - type: git


### PR DESCRIPTION
avogadroapp:
- Fix for background transparency issues when splitting the 3D View Pane

avogadrolibs:
- Improvements to the Molecular Properties dialog:
  - HOMO and LUMO energies added
  - Editable overall charge and multiplicity
  - Other extra properties
- ORCA output file parsing improvements:
  - Imports of ORCA coordinate sets
  - Various types of partial charge
- Keyboard shortcuts for tools now indicated in tooltips
- Support for g-orbitals
- Support for reading DNA/RNA backbones
- Script names and paths now cached for improved startup times
- Scripts that require external dependencies are no longer bundled to avoid confusing error messages (available as downloadable plugins instead)
- Increased precision in XYZ file exports
- Dipole rendering disabled to prevent crashes
- Fix for fragment insertion so that it doesn't leave dummy atoms