### PR TITLE
Bump avogadroapp (fixes) and avogadrolibs (features/fixes)

### DIFF
--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -61,12 +61,12 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: c7c578bec42ba348b08608e0fb151b12b1a721b6
+        commit: f8753691535cfe2442582e523f1b9639afd4c52f
         dest: avogadroapp
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: ca9fa205fde785aed2282ae36acd7c83a7184f5c
+        commit: 42c349aa0d76b08ab561f24b391d075e5033c64c
         dest: avogadrolibs
       # avogadro-i18n
       - type: git


### PR DESCRIPTION
Changes include:
- New conformer properties window
- More MOPAC aux properties are parsed including coordinates
- Improved Python selection
- inputParameters in CJSON now parsed
- Fix for MO rendering when using the flying edges renderer (#1853)
- Fix for crashes when rendering the dipole moment
- Fix for meshes on some platforms (may enable ARM Flatpak)
- Fix for reading radicals from SDF/Molfile
- Fix for script installation
- Various bits of extra debugging info now written to log