### PR TITLE
Bump avogadrolibs (features)

### DIFF
--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -86,7 +86,7 @@ modules:
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: 42c349aa0d76b08ab561f24b391d075e5033c64c
+        commit: b6d6343fd1f831f6c15469ae24bcadf8eab00db3
         dest: avogadrolibs
       # avogadro-i18n
       - type: git


### PR DESCRIPTION
Changes include:
- Type of partial charge is now indicated in properties dialog
- A "Change Elements" command in the Build menu can be used to quickly change the element of an atom
- Atoms can have their element set to "dummy" to make a dummy atom
- Fix for Manipulation and Label Tools so they rotate/navigate by default when their normal function isn't possible, matching the other tools
- Fix for reading properties from CJSON
- Addition of a privacy statement