### PR TITLE
Bump avogadroapp (translations) and avogadrolibs (features)

### DIFF
--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -81,12 +81,12 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: f8753691535cfe2442582e523f1b9639afd4c52f
+        commit: 5d8a673b71c74c17d1560aefe569ada910fd3011
         dest: avogadroapp
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: b6d6343fd1f831f6c15469ae24bcadf8eab00db3
+        commit: 8a57117e94ece2f24f2a5b1af8a7cccc044cdcb1
         dest: avogadrolibs
       # avogadro-i18n
       - type: git


### PR DESCRIPTION
Changes include:
- Return of the molecular orbitals table from Avogadro v1
- Various improvements, refinements, and fixes for the MO table
- Support for atom and bond labels in the property tables
- Progress bar for optimizations and the ability to cancel them
- Improvements to spectra plots, including UV, CD and NMR
- Generation of a surface can now be cancelled
- Improved treatment of bonds in unit cells
- Display of dipole moments is reenabled
- Force field optimization can now be run on ions, and UFF works with radicals too
- Other fixes for force field optimization
- Fix for plugin downloader (but shouldn't have affected Flatpak)
- Fix atom/bond removal when the "Adjust hydrogens" option is turned on
- Fixes for centroid and center-of-mass calculations
- Fix to correctly obtain energies of ORCA MOs
- Small improvement to start-up time by removing a text element from the tool icons