### PR TITLE
Bump openchemistry (build), avogadroapp (features), avogadrolibs (features)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Avogadro is an advanced molecular editor designed for cross-platform use in computational chemistry, molecular modeling, bioinformatics, materials science, and related areas. It offers flexible rendering and a powerful plugin architecture.
+[Avogadro](https://two.avogadro.cc) is an advanced molecular editor designed for cross-platform use in computational chemistry, molecular modeling, bioinformatics, materials science, and related areas. It offers flexible rendering and a powerful plugin architecture.
 
-This repository is for the [Flatpak](https://flatpak.org/) version of Avogadro, which can be downloaded from [Flathub](https://flathub.org/apps/org.openchemistry.Avogadro2).
+This repository is for the [Flatpak](https://flatpak.org) version of Avogadro, which can be downloaded from [Flathub](https://flathub.org/apps/org.openchemistry.Avogadro2).
 
 We also provide a `beta` branch of this Flatpak, which is kept up-to-date with the latest features and fixes; see [the Avogadro website](https://two.avogadro.cc/install/flatpak.html#beta) for instructions on setting it up.
 
 Please only open issues here that specifically concern the Flatpak.
-General bugs and feature requests should be opened at the [main repo](https://github.com/OpenChemistry/avogadrolibs) or posted on [our forum](https://discuss.avogadro.cc/).
+General bugs and feature requests should be opened at the [main repo](https://github.com/OpenChemistry/avogadrolibs) or posted on [our forum](https://discuss.avogadro.cc).
 
 Note that while the Avogadro source code is released under the BSD 3-Clause License, the Flatpak also contains the GPLv2-licensed [Open Babel](https://github.com/openbabel/openbabel).

--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -73,7 +73,7 @@ modules:
       # Clone but not recursively, only want CMake files and dir structure
       - type: git
         url: https://github.com/OpenChemistry/openchemistry.git
-        commit: 4d71cf2b1e42da274ed9aab6cecd2061780d3057
+        commit: 9b2902c532745d9aa129683c5c55773c97135cf8
         disable-shallow-clone: true
         disable-submodules: true
 
@@ -86,7 +86,7 @@ modules:
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: 1ed8c693e175f6c47c14dfa20a8e181c8b8c2113
+        commit: b2fc64825a5d49827115f77e3a8c74bfad68b4ef
         dest: avogadrolibs
       # avogadro-i18n
       - type: git

--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -81,12 +81,12 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: d62927e84e552eb9e266053a4d3c9a9395df53e4
+        commit: e92e70ec6ebfd7d87e868124022f2ad1d75f43aa
         dest: avogadroapp
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: e9a05703a1dc61d5a92fa2a370e31157dd626d46
+        commit: d0a73b8d6ea1d4ed2f63d5766ab833a1d6eede39
         dest: avogadrolibs
       # avogadro-i18n
       - type: git

--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -81,12 +81,12 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: e92e70ec6ebfd7d87e868124022f2ad1d75f43aa
+        commit: abc09fa5da161e4df8252fbfb4d1988128740bd6
         dest: avogadroapp
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: d0a73b8d6ea1d4ed2f63d5766ab833a1d6eede39
+        commit: 8e881b00726f8f9bbe36067fda388ee7e2545384
         dest: avogadrolibs
       # avogadro-i18n
       - type: git

--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -81,12 +81,12 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: f3131df3be0b1fd5589c94761afeff08a9456f7b
+        commit: b8605158b1605ce15d764a2cc30e31c00711415b
         dest: avogadroapp
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: b2fc64825a5d49827115f77e3a8c74bfad68b4ef
+        commit: 02b98bd8c37198bf3bb792bac7bf16262def37f8
         dest: avogadrolibs
       # avogadro-i18n
       - type: git

--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -81,12 +81,12 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: b8605158b1605ce15d764a2cc30e31c00711415b
+        commit: d62927e84e552eb9e266053a4d3c9a9395df53e4
         dest: avogadroapp
       # avogadrolibs
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs.git
-        commit: 02b98bd8c37198bf3bb792bac7bf16262def37f8
+        commit: e9a05703a1dc61d5a92fa2a370e31157dd626d46
         dest: avogadrolibs
       # avogadro-i18n
       - type: git


### PR DESCRIPTION
Changes include:

- Automatic bond length adjustments when elements or bond orders are changed
- QTAIM and Symmetry extensions migrated to Qt6
- "Meshes" renamed to "Surfaces"