### PR TITLE
Update and improve metainfo

### DIFF
--- a/org.openchemistry.Avogadro2.yaml
+++ b/org.openchemistry.Avogadro2.yaml
@@ -80,7 +80,7 @@ modules:
       # avogadroapp
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp.git
-        commit: 1ee80703ba7f1489615f37392d227b8de9a2005c
+        commit: bd51cc2a50c82b54eb77e6bedf1948d4c4109b55
         dest: avogadroapp
       # avogadrolibs
       - type: git


### PR DESCRIPTION
Improves the metainfo to better align with the Freedesktop.org specifications and Flathub standards, including adding proper release notes for this and all past Avogadro2 releases.

New commit used for `avogadroapp` points to a branch that simply adds [these changes to the metainfo](https://github.com/OpenChemistry/avogadroapp/commit/dcddde31975ec295970827949a935ab74dc09e24) onto the 1.100 release code. The build of the Avogadro binary itself remains identical and is the same as the original 1.100.0 release.